### PR TITLE
Add single-quoted nucleotide CIF line parsing support to `basic_fun.h`

### DIFF
--- a/basic_fun.h
+++ b/basic_fun.h
@@ -544,8 +544,8 @@ size_t get_PDB_lines(const string filename,
                 ) continue;
             
             atom=line_vec[_atom_site["label_atom_id"]];
-            if (atom[0]=='"') atom=atom.substr(1);
-            if (atom.size() && atom[atom.size()-1]=='"')
+            if ((atom[0]=='"') || (atom[0]=='\'')) atom=atom.substr(1);
+            if (atom.size() && (atom[atom.size()-1]=='"' || atom[atom.size()-1]=='\''))
                 atom=atom.substr(0,atom.size()-1);
             if (atom.size()==0) continue;
             if      (atom.size()==1) atom=" "+atom+"  ";


### PR DESCRIPTION
* Adds single-quoted nucleotide PDB line parsing support to `basic_fun.h`.
* For example, single quotes for certain mmCIF nucleotide atom IDs (e.g., `'C3''`) are standardized by popular Python mmCIF parsing/writing libraries such as Biopython (reference: https://github.com/biopython/biopython/issues/1784).